### PR TITLE
docs: typo fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,13 @@ repos:
     rev: 0.5.0
     hooks:
       - id: nbstripout
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+        name: codespell
+        description: Checks for common misspellings in text files.
+        entry: codespell --skip="*.json" --ignore-words=.codespell-ignore.txt
+        language: python
+        types: [text]
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Inside the container, you can run the `nvidia-smi` command to verify that your G
 
 ### Training
 #### Syntax
-To train an algorithm on an environemnt use the following command:
+To train an algorithm on an environment use the following command:
 ```python3
 make train script_name=[SCRIPT_NAME] env_name=[ENV_NAME]
 ```
@@ -87,7 +87,7 @@ make adaptation_gravity_sd policy_path=sample/sample_policy/dads-reward-ant-uni-
 
 ### Hierarchical
 #### Syntax
-To perform the Halfcheetah-Hurdle hierarchical task, the user should also provid a policy/repertoire path. The syntax is the following:
+To perform the Halfcheetah-Hurdle hierarchical task, the user should also provide a policy/repertoire path. The syntax is the following:
 
 For QD algorithms:
 ```python

--- a/qdbenchmark/environments/__init__.py
+++ b/qdbenchmark/environments/__init__.py
@@ -1,6 +1,7 @@
 import functools
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import brax
 import jax.numpy as jnp
 from qdax.environments.base_wrappers import QDEnv, StateDescriptorResetWrapper
 from qdax.environments.bd_extractors import (
@@ -13,15 +14,14 @@ from qdax.environments.locomotion_wrappers import (
     XYPositionWrapper,
 )
 from qdax.environments.pointmaze import PointMaze
+
 from qdbenchmark.environments.actuator_wrappers import ActuatorStrengthWrapper
 from qdbenchmark.environments.default_position_wrapper import DefaultPositionWrapper
 from qdbenchmark.environments.exploration_wrappers import MazeWrapper, TrapWrapper
 from qdbenchmark.environments.hurdles_wrapper import HurdlesWrapper
 from qdbenchmark.environments.physics_wrappers import FrictionWrapper, GravityWrapper
 
-import brax
-
-# experimentally determinated offset (except for antmaze)
+# experimentally determined offset (except for antmaze)
 # should be enough to have only positive rewards but no guarantee
 reward_offset = {
     "pointmaze": 2.3431,
@@ -111,7 +111,7 @@ def create(
             env = brax.envs._envs[base_env_name](legacy_spring=True, **kwargs)
         elif base_env_name in _qdbenchmark_envs.keys():
             # WARNING: not general!! temporary trick
-            env = _qdbenchmark_envs[base_env_name](**kwargs)
+            env = _qdbenchmark_envs[base_env_name](**kwargs)  # type: ignore
 
         # roll with qdbenchmark wrappers
         wrappers = _qdbenchmark_custom_envs[env_name]["wrappers"]

--- a/qdbenchmark/training/train_aurora.py
+++ b/qdbenchmark/training/train_aurora.py
@@ -27,6 +27,7 @@ from qdax.tasks.brax_envs import (
 )
 from qdax.utils import train_seq2seq
 from qdax.utils.metrics import CSVLogger
+
 from qdbenchmark import environments
 from qdbenchmark.utils.logging import LoggingConfig
 from qdbenchmark.utils.plotting import plot_2d_map_elites_repertoire
@@ -239,7 +240,7 @@ def train(config: ExperimentConfig) -> None:
 
     @jax.jit
     def update_scan_fn(carry: Any, unused: Any) -> Any:
-        """Scan the udpate function."""
+        """Scan the update function."""
         (
             repertoire,
             random_key,
@@ -249,12 +250,7 @@ def train(config: ExperimentConfig) -> None:
         ) = carry
 
         # update
-        (
-            repertoire,
-            _,
-            metrics,
-            random_key,
-        ) = aurora.update(
+        (repertoire, _, metrics, random_key,) = aurora.update(
             repertoire,
             None,
             random_key,

--- a/qdbenchmark/training/train_pga_aurora.py
+++ b/qdbenchmark/training/train_pga_aurora.py
@@ -27,6 +27,7 @@ from qdax.tasks.brax_envs import (
 )
 from qdax.utils import train_seq2seq
 from qdax.utils.metrics import CSVLogger
+
 from qdbenchmark import environments
 from qdbenchmark.utils.logging import LoggingConfig
 from qdbenchmark.utils.plotting import plot_2d_map_elites_repertoire
@@ -284,7 +285,7 @@ def train(config: ExperimentConfig) -> None:
 
     @jax.jit
     def update_scan_fn(carry: Any, unused: Any) -> Any:
-        """Scan the udpate function."""
+        """Scan the update function."""
         (
             repertoire,
             emitter_state,
@@ -295,12 +296,7 @@ def train(config: ExperimentConfig) -> None:
         ) = carry
 
         # update
-        (
-            repertoire,
-            emitter_state,
-            metrics,
-            random_key,
-        ) = aurora.update(
+        (repertoire, emitter_state, metrics, random_key,) = aurora.update(
             repertoire,
             emitter_state,
             random_key,


### PR DESCRIPTION
I also add a pre-commit hook to codespell to catch typos earlier.

I've added a `# type: ignore` to line 114 of `qdbenchmark/environments/__init__.py` because `mypy` was complaining about that line.